### PR TITLE
Etiquetado de versiones y observabilidad del Worker del frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,16 @@ jobs:
       # writing to real boards.
       - run: npm run build:preview
 
-      - run: npm run deploy:preview
+      # `--tag` and `--message` are the only thread back to here. Cloudflare
+      # records the version but knows nothing of the build that produced it, so
+      # without them its Deployments tab is a list of bare hashes and timestamps.
+      # The subject is cut at 80 characters because commit subjects here are not
+      # always short and the annotation is read in a narrow column.
+      - name: Upload the preview version
+        run: |
+          npm run deploy:preview -- \
+            --tag "$(git rev-parse --short HEAD)" \
+            --message "$(git log -1 --pretty=%s | cut -c1-80) · run ${{ github.run_number }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -105,7 +114,14 @@ jobs:
 
       - run: npm run build
 
-      - run: npm run deploy:cf
+      # Same annotations as the preview job. On master the subject is usually
+      # the merge commit's — "Merge pull request #14 from gmujica/dev" — which
+      # is what makes the version findable from the PR it came from.
+      - name: Deploy to production
+        run: |
+          npm run deploy:cf -- \
+            --tag "$(git rev-parse --short HEAD)" \
+            --message "$(git log -1 --pretty=%s | cut -c1-80) · run ${{ github.run_number }}"
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,3 +25,22 @@ directory = "./dist"
 # than `/` — or opens a link to one — still has to be handed index.html. The
 # default is `none`, which serves the 404 page instead.
 not_found_handling = "single-page-application"
+
+# On, and recording nothing — which is the point of writing it down rather than
+# leaving it out. A Worker with no `main` is never invoked: requests to static
+# assets are served ahead of any script and are free, so there are no
+# invocations to log, no `console.log` to collect, and no fetch, binding or
+# handler calls for tracing to instrument. An empty panel is the correct result
+# here, not a misconfiguration.
+#
+# It is here for the day this Worker gains code. The likeliest reason is putting
+# `/api/*` behind this origin as a proxy to ptm-api, which would also stop the
+# session cookie from being third-party and fix sign-in in Safari. On that day
+# logs should already be on, rather than be remembered a debugging session too
+# late. Until then it costs nothing, because nothing is emitted.
+#
+# Traces stay off for the same reason, and because there is nothing to trace
+# even in that future until the proxy exists. They are on in ptm-api instead,
+# where the D1 queries and the round trip to GitHub actually live.
+[observability]
+enabled = true


### PR DESCRIPTION
Dos commits de infraestructura, sin cambios de producto ni de UI.

- **`67e70c8`** — las versiones subidas a Cloudflare se etiquetan con el commit
  corto y el asunto que las produjo. Sin esto la pestaña de Deployments es una
  lista de hashes sin relación con lo que hay en el repo.
- **`7633028`** — queda declarado el bloque de observabilidad en `wrangler.toml`,
  encendido y sin emitir nada: un Worker sin `main` nunca se invoca, así que un
  panel vacío es el resultado correcto. Está escrito para el día en que este
  Worker tenga código, que muy probablemente sea poner `/api/*` detrás de este
  origen como proxy.

La suite pasa entera en local: 11 archivos, 221 tests.
